### PR TITLE
Performance tuning

### DIFF
--- a/src/eclat.jl
+++ b/src/eclat.jl
@@ -64,7 +64,7 @@ function eclat(txns::Transactions, min_support::Union{Int,Float64})::DataFrame
         for i in eachindex(items)
             item = items[i]
             new_lineage = vcat(lineage, item)
-            support = length(findall(all(trans[:, new_lineage] .== 1, dims=2)))
+            support = sum(all(trans[:, new_lineage], dims=2))
     
             if support >= min_support
                 set = Itemset(new_lineage, support, length(new_lineage))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,24 +8,24 @@ using Test
             data = load_transactions(joinpath(@__DIR__,"files/data.txt"),',')
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
-            @test hash(sort(collect(values(data.linekeys)))) == 1066772112083085456
+            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
+            @test hash(sort(collect(values(data.linekeys)))) == UInt64(1066772112083085456)
         end
 
         @testset "line indexes" begin
             data = load_transactions(joinpath(@__DIR__,"files/data_indexed.txt"),',';id_col = true)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
-            @test hash(sort(collect(values(data.linekeys)))) == 10356874651475808405
+            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
+            @test hash(sort(collect(values(data.linekeys)))) == UInt64(10356874651475808405)
         end
 
         @testset "skip lines" begin
             data = load_transactions(joinpath(@__DIR__,"files/data_header.txt"),',';skiplines=2)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
-            @test hash(sort(collect(values(data.linekeys)))) == 1066772112083085456
+            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
+            @test hash(sort(collect(values(data.linekeys)))) == UInt64(1066772112083085456)
         end
     end
 
@@ -40,16 +40,16 @@ using Test
             data = transactions(dftest)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
-            @test hash(sort(collect(values(data.linekeys)))) == 1066772112083085456
+            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
+            @test hash(sort(collect(values(data.linekeys)))) == UInt64(1066772112083085456)
         end
 
         @testset "with index" begin
             data = transactions(dftest_index;indexcol=:Index)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
-            @test hash(sort(collect(values(data.linekeys)))) == 10356874651475808405
+            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
+            @test hash(sort(collect(values(data.linekeys)))) == UInt64(10356874651475808405)
         end
 
     end
@@ -62,28 +62,28 @@ end
         rules = apriori(data,0.3,5)
         transform!(rules,:LHS =>( x -> hash.(x) ) => :SetHash)
         sort!(rules,[:Length,:SetHash,:RHS])
-        @test hash(rules.LHS) == 10944680318112923216
-        @test hash(rules.RHS) == 7170342362675143343
-        @test hash(rules.Support) == 18329550519797518446
-        @test hash(rules.Confidence) == 10378668557036289636
-        @test hash(rules.Coverage) == 17208738295533172824
-        @test hash(rules.Lift) == 18282341198944935968
-        @test hash(rules.N) == 2389578521758638798
-        @test hash(rules.Length) == 12370468415001452020
+        @test hash(rules.LHS) == UInt64(10944680318112923216)
+        @test hash(rules.RHS) == UInt64(7170342362675143343)
+        @test hash(rules.Support) == UInt64(18329550519797518446)
+        @test hash(rules.Confidence) == UInt64(10378668557036289636)
+        @test hash(rules.Coverage) == UInt64(17208738295533172824)
+        @test hash(rules.Lift) == UInt64(18282341198944935968)
+        @test hash(rules.N) == UInt64(2389578521758638798)
+        @test hash(rules.Length) == UInt64(12370468415001452020)
     end
 
     @testset "absolute support" begin
         rules = apriori(data,2,5)
         transform!(rules,:LHS =>( x -> hash.(x) ) => :SetHash)
         sort!(rules,[:Length,:SetHash,:RHS])
-        @test hash(rules.LHS) == 10944680318112923216
-        @test hash(rules.RHS) == 7170342362675143343
-        @test hash(rules.Support) == 18329550519797518446
-        @test hash(rules.Confidence) == 10378668557036289636
-        @test hash(rules.Coverage) == 17208738295533172824
-        @test hash(rules.Lift) == 18282341198944935968
-        @test hash(rules.N) == 2389578521758638798
-        @test hash(rules.Length) == 12370468415001452020
+        @test hash(rules.LHS) == UInt64(10944680318112923216)
+        @test hash(rules.RHS) == UInt64(7170342362675143343)
+        @test hash(rules.Support) == UInt64(18329550519797518446)
+        @test hash(rules.Confidence) == UInt64(10378668557036289636)
+        @test hash(rules.Coverage) == UInt64(17208738295533172824)
+        @test hash(rules.Lift) == UInt64(18282341198944935968)
+        @test hash(rules.N) == UInt64(2389578521758638798)
+        @test hash(rules.Length) == UInt64(12370468415001452020)
     end
 end
 
@@ -94,19 +94,19 @@ end
         sets = eclat(data,0.3)
         transform!(sets,:Itemset =>( x -> hash.(x) ) => :SetHash)
         sort!(sets,[:Length,:SetHash])
-        @test hash(sets.Itemset) == 9215540465155188081
-        @test hash(sets.Support) == 9491076249976136591
-        @test hash(sets.N) == 13538681268459648389
-        @test hash(sets.Length) == 3041221529991437560
+        @test hash(sets.Itemset) == UInt64(9215540465155188081)
+        @test hash(sets.Support) == UInt64(9491076249976136591)
+        @test hash(sets.N) == UInt64(13538681268459648389)
+        @test hash(sets.Length) == UInt64(3041221529991437560)
     end
     
     @testset "asbolute support" begin
         sets = eclat(data,3)
         transform!(sets,:Itemset =>( x -> hash.(x) ) => :SetHash)
         sort!(sets,[:Length,:SetHash])
-        @test hash(sets.Itemset) == 9215540465155188081
-        @test hash(sets.Support) == 9491076249976136591
-        @test hash(sets.N) == 13538681268459648389
-        @test hash(sets.Length) == 3041221529991437560
+        @test hash(sets.Itemset) == UInt64(9215540465155188081)
+        @test hash(sets.Support) == UInt64(9491076249976136591)
+        @test hash(sets.N) == UInt64(13538681268459648389)
+        @test hash(sets.Length) == UInt64(3041221529991437560)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,24 +8,24 @@ using Test
             data = load_transactions(joinpath(@__DIR__,"files/data.txt"),',')
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
-            @test hash(sort(collect(values(data.linekeys)))) == UInt64(1066772112083085456)
+            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
+            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
         end
 
         @testset "line indexes" begin
             data = load_transactions(joinpath(@__DIR__,"files/data_indexed.txt"),',';id_col = true)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
-            @test hash(sort(collect(values(data.linekeys)))) == UInt64(10356874651475808405)
+            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
+            @test sort(collect(values(data.linekeys))) == ["1111", "1112", "1113", "1114", "1115", "1116", "1117", "1118", "1119"]
         end
 
         @testset "skip lines" begin
             data = load_transactions(joinpath(@__DIR__,"files/data_header.txt"),',';skiplines=2)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
-            @test hash(sort(collect(values(data.linekeys)))) == UInt64(1066772112083085456)
+            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
+            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
         end
     end
 
@@ -40,16 +40,16 @@ using Test
             data = transactions(dftest)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
-            @test hash(sort(collect(values(data.linekeys)))) == UInt64(1066772112083085456)
+            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
+            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
         end
 
         @testset "with index" begin
             data = transactions(dftest_index;indexcol=:Index)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test hash(sort(collect(values(data.colkeys)))) == UInt64(14154404351539088851)
-            @test hash(sort(collect(values(data.linekeys)))) == UInt64(10356874651475808405)
+            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
+            @test sort(collect(values(data.linekeys))) == ["1111", "1112", "1113", "1114", "1115", "1116", "1117", "1118", "1119"]
         end
 
     end
@@ -60,30 +60,28 @@ end
 
     @testset "percentage support" begin
         rules = apriori(data,0.3,5)
-        transform!(rules,:LHS =>( x -> hash.(x) ) => :SetHash)
-        sort!(rules,[:Length,:SetHash,:RHS])
-        @test hash(rules.LHS) == UInt64(10944680318112923216)
-        @test hash(rules.RHS) == UInt64(7170342362675143343)
-        @test hash(rules.Support) == UInt64(18329550519797518446)
-        @test hash(rules.Confidence) == UInt64(10378668557036289636)
-        @test hash(rules.Coverage) == UInt64(17208738295533172824)
-        @test hash(rules.Lift) == UInt64(18282341198944935968)
-        @test hash(rules.N) == UInt64(2389578521758638798)
-        @test hash(rules.Length) == UInt64(12370468415001452020)
+        sorted = sort(rules,[:Support,:RHS])
+        @test sorted.LHS == [String[], String[], String[], String[], ["milk"], ["eggs"], String[], String[]]
+        @test sorted.RHS == ["beer", "bread", "cheese", "ham", "eggs", "milk", "eggs", "milk"]
+        @test sorted.Support == [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.4444444444444444, 0.4444444444444444, 0.5555555555555556, 0.5555555555555556]
+        @test sorted.Confidence ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.7999999999999999, 0.7999999999999999, 0.5555555555555556, 0.5555555555555556]
+        @test sorted.Coverage ≈ [1.0, 1.0, 1.0, 1.0, 0.5555555555555556, 0.5555555555555556, 1.0, 1.0]
+        @test sorted.Lift ≈ [1.0, 1.0, 1.0, 1.0, 1.4399999999999997, 1.4399999999999997, 1.0, 1.0]
+        @test sorted.N == [3, 3, 3, 3, 4, 4, 5, 5]
+        @test sorted.Length == [1, 1, 1, 1, 2, 2, 1, 1]
     end
 
     @testset "absolute support" begin
         rules = apriori(data,2,5)
-        transform!(rules,:LHS =>( x -> hash.(x) ) => :SetHash)
-        sort!(rules,[:Length,:SetHash,:RHS])
-        @test hash(rules.LHS) == UInt64(10944680318112923216)
-        @test hash(rules.RHS) == UInt64(7170342362675143343)
-        @test hash(rules.Support) == UInt64(18329550519797518446)
-        @test hash(rules.Confidence) == UInt64(10378668557036289636)
-        @test hash(rules.Coverage) == UInt64(17208738295533172824)
-        @test hash(rules.Lift) == UInt64(18282341198944935968)
-        @test hash(rules.N) == UInt64(2389578521758638798)
-        @test hash(rules.Length) == UInt64(12370468415001452020)
+        sorted = sort(rules,[:Support,:RHS])
+        @test sorted.LHS == [String[], String[], String[], String[], ["milk"], ["eggs"], String[], String[]]
+        @test sorted.RHS == ["beer", "bread", "cheese", "ham", "eggs", "milk", "eggs", "milk"]
+        @test sorted.Support == [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.4444444444444444, 0.4444444444444444, 0.5555555555555556, 0.5555555555555556]
+        @test sorted.Confidence ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.7999999999999999, 0.7999999999999999, 0.5555555555555556, 0.5555555555555556]
+        @test sorted.Coverage ≈ [1.0, 1.0, 1.0, 1.0, 0.5555555555555556, 0.5555555555555556, 1.0, 1.0]
+        @test sorted.Lift ≈ [1.0, 1.0, 1.0, 1.0, 1.4399999999999997, 1.4399999999999997, 1.0, 1.0]
+        @test sorted.N == [3, 3, 3, 3, 4, 4, 5, 5]
+        @test sorted.Length == [1, 1, 1, 1, 2, 2, 1, 1]
     end
 end
 
@@ -92,21 +90,19 @@ end
     
     @testset "percentage support" begin
         sets = eclat(data,0.3)
-        transform!(sets,:Itemset =>( x -> hash.(x) ) => :SetHash)
-        sort!(sets,[:Length,:SetHash])
-        @test hash(sets.Itemset) == UInt64(9215540465155188081)
-        @test hash(sets.Support) == UInt64(9491076249976136591)
-        @test hash(sets.N) == UInt64(13538681268459648389)
-        @test hash(sets.Length) == UInt64(3041221529991437560)
+        sorted = sort(sets,[:N,:Itemset])
+        @test sets.Itemset == [["bread"], ["beer"], ["ham"], ["cheese"], ["milk"], ["milk", "eggs"], ["eggs"]]
+        @test sets.Support ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.5555555555555556, 0.4444444444444444, 0.5555555555555556]
+        @test sets.N == [3, 3, 3, 3, 5, 4, 5]
+        @test sets.Length == [1, 1, 1, 1, 1, 2, 1]
     end
     
     @testset "asbolute support" begin
         sets = eclat(data,3)
-        transform!(sets,:Itemset =>( x -> hash.(x) ) => :SetHash)
-        sort!(sets,[:Length,:SetHash])
-        @test hash(sets.Itemset) == UInt64(9215540465155188081)
-        @test hash(sets.Support) == UInt64(9491076249976136591)
-        @test hash(sets.N) == UInt64(13538681268459648389)
-        @test hash(sets.Length) == UInt64(3041221529991437560)
+        sorted = sort(sets,[:N,:Itemset])
+        @test sets.Itemset == [["bread"], ["beer"], ["ham"], ["cheese"], ["milk"], ["milk", "eggs"], ["eggs"]]
+        @test sets.Support ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.5555555555555556, 0.4444444444444444, 0.5555555555555556]
+        @test sets.N == [3, 3, 3, 3, 5, 4, 5]
+        @test sets.Length == [1, 1, 1, 1, 1, 2, 1]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,19 +90,21 @@ end
     
     @testset "percentage support" begin
         sets = eclat(data,0.3)
-        sorted = sort(sets,[:N,:Itemset])
-        @test sets.Itemset == [["bread"], ["beer"], ["ham"], ["cheese"], ["milk"], ["milk", "eggs"], ["eggs"]]
-        @test sets.Support ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.5555555555555556, 0.4444444444444444, 0.5555555555555556]
-        @test sets.N == [3, 3, 3, 3, 5, 4, 5]
-        @test sets.Length == [1, 1, 1, 1, 1, 2, 1]
+        transform!(sets,:Itemset =>( x -> join.(x) ) => :SetHash)
+        sort!(sets,[:Length,:SetHash])
+        @test sets.Itemset == [["beer"], ["bread"], ["cheese"], ["eggs"], ["ham"], ["milk"], ["milk", "eggs"]]
+        @test sets.Support ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.5555555555555556, 0.3333333333333333, 0.5555555555555556, 0.4444444444444444]
+        @test sets.N == [3, 3, 3, 5, 3, 5, 4]
+        @test sets.Length == [1, 1, 1, 1, 1, 1, 2]
     end
     
     @testset "asbolute support" begin
         sets = eclat(data,3)
-        sorted = sort(sets,[:N,:Itemset])
-        @test sets.Itemset == [["bread"], ["beer"], ["ham"], ["cheese"], ["milk"], ["milk", "eggs"], ["eggs"]]
-        @test sets.Support ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.5555555555555556, 0.4444444444444444, 0.5555555555555556]
-        @test sets.N == [3, 3, 3, 3, 5, 4, 5]
-        @test sets.Length == [1, 1, 1, 1, 1, 2, 1]
+        transform!(sets,:Itemset =>( x -> join.(x) ) => :SetHash)
+        sort!(sets,[:Length,:SetHash])
+        @test sets.Itemset == [["beer"], ["bread"], ["cheese"], ["eggs"], ["ham"], ["milk"], ["milk", "eggs"]]
+        @test sets.Support ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.5555555555555556, 0.3333333333333333, 0.5555555555555556, 0.4444444444444444]
+        @test sets.N == [3, 3, 3, 5, 3, 5, 4]
+        @test sets.Length == [1, 1, 1, 1, 1, 1, 2]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,24 +8,24 @@ using Test
             data = load_transactions(joinpath(@__DIR__,"files/data.txt"),',')
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
+            @test hash(sort(collect(values(data.linekeys)))) == 1066772112083085456
         end
 
         @testset "line indexes" begin
             data = load_transactions(joinpath(@__DIR__,"files/data_indexed.txt"),',';id_col = true)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1111", "1112", "1113", "1114", "1115", "1116", "1117", "1118", "1119"]
+            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
+            @test hash(sort(collect(values(data.linekeys)))) == 10356874651475808405
         end
 
         @testset "skip lines" begin
             data = load_transactions(joinpath(@__DIR__,"files/data_header.txt"),',';skiplines=2)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
+            @test hash(sort(collect(values(data.linekeys)))) == 1066772112083085456
         end
     end
 
@@ -40,16 +40,16 @@ using Test
             data = transactions(dftest)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
+            @test hash(sort(collect(values(data.linekeys)))) == 1066772112083085456
         end
 
         @testset "with index" begin
             data = transactions(dftest_index;indexcol=:Index)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1111", "1112", "1113", "1114", "1115", "1116", "1117", "1118", "1119"]
+            @test hash(sort(collect(values(data.colkeys)))) == 14154404351539088851
+            @test hash(sort(collect(values(data.linekeys)))) == 10356874651475808405
         end
 
     end
@@ -60,28 +60,30 @@ end
 
     @testset "percentage support" begin
         rules = apriori(data,0.3,5)
-        sorted = sort(rules,[:Support,:RHS])
-        @test sorted.LHS == [String[], String[], String[], String[], ["milk"], ["eggs"], String[], String[]]
-        @test sorted.RHS == ["beer", "bread", "cheese", "ham", "eggs", "milk", "eggs", "milk"]
-        @test sorted.Support == [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.4444444444444444, 0.4444444444444444, 0.5555555555555556, 0.5555555555555556]
-        @test sorted.Confidence ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.7999999999999999, 0.7999999999999999, 0.5555555555555556, 0.5555555555555556]
-        @test sorted.Coverage ≈ [1.0, 1.0, 1.0, 1.0, 0.5555555555555556, 0.5555555555555556, 1.0, 1.0]
-        @test sorted.Lift ≈ [1.0, 1.0, 1.0, 1.0, 1.4399999999999997, 1.4399999999999997, 1.0, 1.0]
-        @test sorted.N == [3, 3, 3, 3, 4, 4, 5, 5]
-        @test sorted.Length == [1, 1, 1, 1, 2, 2, 1, 1]
+        transform!(rules,:LHS =>( x -> hash.(x) ) => :SetHash)
+        sort!(rules,[:Length,:SetHash,:RHS])
+        @test hash(rules.LHS) == 10944680318112923216
+        @test hash(rules.RHS) == 7170342362675143343
+        @test hash(rules.Support) == 18329550519797518446
+        @test hash(rules.Confidence) == 10378668557036289636
+        @test hash(rules.Coverage) == 17208738295533172824
+        @test hash(rules.Lift) == 18282341198944935968
+        @test hash(rules.N) == 2389578521758638798
+        @test hash(rules.Length) == 12370468415001452020
     end
 
     @testset "absolute support" begin
         rules = apriori(data,2,5)
-        sorted = sort(rules,[:Support,:RHS])
-        @test sorted.LHS == [String[], String[], String[], String[], ["milk"], ["eggs"], String[], String[]]
-        @test sorted.RHS == ["beer", "bread", "cheese", "ham", "eggs", "milk", "eggs", "milk"]
-        @test sorted.Support == [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.4444444444444444, 0.4444444444444444, 0.5555555555555556, 0.5555555555555556]
-        @test sorted.Confidence ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.7999999999999999, 0.7999999999999999, 0.5555555555555556, 0.5555555555555556]
-        @test sorted.Coverage ≈ [1.0, 1.0, 1.0, 1.0, 0.5555555555555556, 0.5555555555555556, 1.0, 1.0]
-        @test sorted.Lift ≈ [1.0, 1.0, 1.0, 1.0, 1.4399999999999997, 1.4399999999999997, 1.0, 1.0]
-        @test sorted.N == [3, 3, 3, 3, 4, 4, 5, 5]
-        @test sorted.Length == [1, 1, 1, 1, 2, 2, 1, 1]
+        transform!(rules,:LHS =>( x -> hash.(x) ) => :SetHash)
+        sort!(rules,[:Length,:SetHash,:RHS])
+        @test hash(rules.LHS) == 10944680318112923216
+        @test hash(rules.RHS) == 7170342362675143343
+        @test hash(rules.Support) == 18329550519797518446
+        @test hash(rules.Confidence) == 10378668557036289636
+        @test hash(rules.Coverage) == 17208738295533172824
+        @test hash(rules.Lift) == 18282341198944935968
+        @test hash(rules.N) == 2389578521758638798
+        @test hash(rules.Length) == 12370468415001452020
     end
 end
 
@@ -90,19 +92,21 @@ end
     
     @testset "percentage support" begin
         sets = eclat(data,0.3)
-        sorted = sort(sets,[:N,:Itemset])
-        @test sets.Itemset == [["bread"], ["beer"], ["ham"], ["cheese"], ["milk"], ["milk", "eggs"], ["eggs"]]
-        @test sets.Support ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.5555555555555556, 0.4444444444444444, 0.5555555555555556]
-        @test sets.N == [3, 3, 3, 3, 5, 4, 5]
-        @test sets.Length == [1, 1, 1, 1, 1, 2, 1]
+        transform!(sets,:Itemset =>( x -> hash.(x) ) => :SetHash)
+        sort!(sets,[:Length,:SetHash])
+        @test hash(sets.Itemset) == 9215540465155188081
+        @test hash(sets.Support) == 9491076249976136591
+        @test hash(sets.N) == 13538681268459648389
+        @test hash(sets.Length) == 3041221529991437560
     end
     
     @testset "asbolute support" begin
         sets = eclat(data,3)
-        sorted = sort(sets,[:N,:Itemset])
-        @test sets.Itemset == [["bread"], ["beer"], ["ham"], ["cheese"], ["milk"], ["milk", "eggs"], ["eggs"]]
-        @test sets.Support ≈ [0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.3333333333333333, 0.5555555555555556, 0.4444444444444444, 0.5555555555555556]
-        @test sets.N == [3, 3, 3, 3, 5, 4, 5]
-        @test sets.Length == [1, 1, 1, 1, 1, 2, 1]
+        transform!(sets,:Itemset =>( x -> hash.(x) ) => :SetHash)
+        sort!(sets,[:Length,:SetHash])
+        @test hash(sets.Itemset) == 9215540465155188081
+        @test hash(sets.Support) == 9491076249976136591
+        @test hash(sets.N) == 13538681268459648389
+        @test hash(sets.Length) == 3041221529991437560
     end
 end


### PR DESCRIPTION
Reworked both the A Priori Algorithm and ECLAT algorithms to operate faster. Depending on the dataset and parameters, I'm seeing:
- 20-40% improvement in A Priori speed
- 30-50% improvement in ECLAT speed.

## A Priori Changes:
### Added transaction database subsetting
In the old implementation, each child node search was also calculating support for all columns that don't meet the minimum support threshold. With this change, the algorithm now only calculates support for the base nodes in each iteration.

### Added hashing and deduplication of rules during generation
A Priori tends to create redundant rules where the LHS will have the same items in a different order. This can be solved with sets or bitsets, but converting to and from these to vectors to slice the transactions matrix is very slow.

The solution used here keeps the vector architecture for fast matrix slicing, but removes redundant rules at each level of calculation. This prevents further rule generation based on the redundant rules, and it provides greater resource savings the greater maximum length of the rules being generated.

## ECLAT Changes
### Enabled multithreading
Enabling multithreading in ECLAT is tricky because of its recursive nature. This approach multi-threads at the first equivalence class, keeping the threads entirely independent.

This speeds up ECLAT significantly, but the amount of computation each thread does is very uneven due to the search pattern in ECLAT. Adding additional cores will see diminishing returns on speed gains.

## Testing Changes
### Sorted itemsets generated by ECLAT
Sorting the itemsets is now necessary with the introduction of multithreading.