### PR TITLE
Add partial loading of files with nlines kwarg

### DIFF
--- a/docs/src/transactions.md
+++ b/docs/src/transactions.md
@@ -29,6 +29,7 @@ Parameters:
 - `delimiter`: Character used to separate items in each transaction
 - `id_col`: Set to true if the first item in each line is a transaction identifier (default: false)
 - `skiplines`: Number of header lines to skip (optional)
+- `nlines`:Number of lines to read (optional)
 
 Returns: 
 - `Transactions`: A Transactions object with a sparse matrix representing the treansactions (rows) and items (columns) as well as dictionary keys for the names of the rows and columns

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -37,15 +37,17 @@ function getnames(indexes::Vector{Int},txns::Transactions)
 end
 
 """
-    load_transactions(file::String, delimiter::Char; id_col::Bool= false)::Transactions
+    load_transactions(file::String, delimiter::Char; id_col::Bool= false, skiplines::Int= 0, nlines::Int= 0)::Transactions
 
 Read transaction data from a `file` where each line is a list of items separated by a given `delimiter`
 
 If the first item of each list is a transaction identifier, set `id_col` to `true`
 
 Specify the number header lines to skip with `skiplines`
+
+Specify a specific number of lines to read with `nlines`
 """
-function load_transactions(file::String, delimiter::Char; id_col::Bool = false, skiplines::Int = 0)::Transactions
+function load_transactions(file::String, delimiter::Char; id_col::Bool = false, skiplines::Int = 0, nlines::Int = 0)::Transactions
 
     io = Mmap.mmap(file)
     
@@ -91,6 +93,9 @@ function load_transactions(file::String, delimiter::Char; id_col::Bool = false, 
                 value_index += 1
             end
             first_item = false
+        end
+        if nlines != 0 && line_number == abs(nlines)
+            break
         end
         line_number += 1
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,14 @@ using Test
             @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
             @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
         end
+
+        @testset "n lines" begin
+            data = load_transactions(joinpath(@__DIR__,"files/data.txt"),',',nlines = 1)
+            @test size(data.matrix) == (1,3)
+            @test sum(data.matrix) == 3
+            @test sort(collect(values(data.colkeys))) == ["bread", "eggs", "milk"]
+            @test sort(collect(values(data.linekeys))) == ["1"]
+        end
     end
 
     @testset "convert df" begin


### PR DESCRIPTION
Add kwarg to load_transactions() to allow specifying the number of lines to read from the file