### PR TITLE
Clean up and reorganize for 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The package currently has support for these algorithms:
 - CHARM[^5]
 - LCM[^6]
 - CARPENTER[^7]
+- LevelWise[^8] (for recovering frequent itemsets)
 
 ## Installation
 ```
@@ -118,7 +119,7 @@ See [this post](https://julialang.org/blog/2019/07/multithreading/) for more inf
 > Multithreading can be configured for the VScode integrated terminal by setting the `julia.NumThreads` parameter in VScode settings.
 
 ## Future Work
-RuleMiner 0.3.0 is planned to support closed itemset mining in addition to frequent itemset mining.
+RuleMiner 0.4.0 is planned to support maximal itemset mining.
 
 ## References
 [^1]: Agrawal, Rakesh, and Ramakrishnan Srikant. “Fast Algorithms for Mining Association Rules in Large Databases.” In Proceedings of the 20th International Conference on Very Large Data Bases, 487–99. VLDB ’94. San Francisco, CA, USA: Morgan Kaufmann Publishers Inc., 1994.
@@ -134,3 +135,5 @@ RuleMiner 0.3.0 is planned to support closed itemset mining in addition to frequ
 [^6]: Uno, Takeaki, Tatsuya Asai, Yuzo Uchida, and Hiroki Arimura. “An Efficient Algorithm for Enumerating Closed Patterns in Transaction Databases.” In Discovery Science, edited by Einoshin Suzuki and Setsuo Arikawa, 16–31. Berlin, Heidelberg: Springer, 2004. https://doi.org/10.1007/978-3-540-30214-8_2.
 
 [^7]: Pan, Feng, Gao Cong, Anthony K. H. Tung, Jiong Yang, and Mohammed J. Zaki. “Carpenter: Finding Closed Patterns in Long Biological Datasets.” In Proceedings of the Ninth ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, 637–42. KDD ’03. New York, NY, USA: Association for Computing Machinery, 2003. https://doi.org/10.1145/956750.956832.
+
+[^8]: Pasquier, Nicolas, Yves Bastide, Rafik Taouil, and Lotfi Lakhal. “Efficient Mining of Association Rules Using Closed Itemset Lattices.” Information Systems 24, no. 1 (March 1, 1999): 25–46. https://doi.org/10.1016/S0306-4379(99)00003-4.

--- a/docs/src/algorithms/apriori.md
+++ b/docs/src/algorithms/apriori.md
@@ -32,10 +32,6 @@ The function returns a `DataFrame` containing the discovered association rules. 
 4. These candidate rules are then evaluated on whether they meet the minimum support citeria.
 5. Various metrics (support, confidence, coverage, lift) are calculated for each rule which meets the `min_support` criterion.
 
-## Performance Considerations
-
-This function uses Julia's multithreading capabilities to parallelize the generation and evaluation of candidate nodes, which can significantly improve performance on multi-core systems with Julia's native multithreading enabled.
-
 ## Usage Example
 
 ```julia

--- a/docs/src/algorithms/carpenter.md
+++ b/docs/src/algorithms/carpenter.md
@@ -20,7 +20,7 @@ A DataFrame object with four columns:
 - `N`: Absolute support count of the itemset
 - `Length`: Number of items in the itemset
 
-Algorithm Overview
+## Algorithm Overview
 
 1. Check if the current itemset has been discovered before (pruning 3)
 2. Calculate the support of the current itemset
@@ -30,6 +30,7 @@ Algorithm Overview
 6. Add closed frequent itemsets to the results
 7. Recursively enumerate larger itemsets
 
+## Usage Example
 ```julia
 # Load transactions
 txns = load_transactions("transactions.txt", ' ')

--- a/docs/src/algorithms/charm.md
+++ b/docs/src/algorithms/charm.md
@@ -20,7 +20,7 @@ A DataFrame object with four columns:
 - `N`: Absolute support count of the itemset
 - `Length`: Number of items in the itemset
 
-Algorithm Overview
+## Algorithm Overview
 
 1. The function starts by initializing tidsets (transaction ID sets) for each item.
 2. It then generates an ordered list of frequent items based on the minimum support threshold.
@@ -28,7 +28,7 @@ Algorithm Overview
 4. For each itemset, it checks if it's closed by comparing it with previously found closed itemsets.
 5. The process continues recursively, building larger itemsets from smaller ones.
 
-
+## Usage Example
 ```julia
 # Load transactions
 txns = load_transactions("transactions.txt", ' ')

--- a/docs/src/algorithms/eclat.md
+++ b/docs/src/algorithms/eclat.md
@@ -2,7 +2,6 @@
 
 The `eclat` function implements the **E**quivalence **CLA**ss **T**ransformation algorithm for frequent itemset mining proposed by Mohammad Zaki in 2000. This algorithm identifies frequent itemsets in a dataset utilizing a column-first search and supplied minimum support.
 
-## Function signature
 ```@docs
 eclat(txns::Transactions, min_support::Union{Int,Float64})
 ```

--- a/docs/src/algorithms/fpclose.md
+++ b/docs/src/algorithms/fpclose.md
@@ -24,7 +24,7 @@ A DataFrame object with four columns:
 Algorithm Overview
 
 1. The function starts by constructing an FP-tree from the transaction dataset.
-2. It then recursively mines the FP-tree to find all candiadte closed itemsets.
+2. It then recursively mines the FP-tree to find all candidate closed itemsets.
 3. Prune non-closed itemsets by checking for supersets with the same support.
 4. The process continues until all frequent itemsets are discovered.
 

--- a/docs/src/algorithms/fpgrowth.md
+++ b/docs/src/algorithms/fpgrowth.md
@@ -20,7 +20,7 @@ A DataFrame object with four columns:
 - `N`: Absolute support count of the itemset
 - `Length`: Number of items in the itemset
 
-Algorithm Overview
+## Algorithm Overview
 
 1. The function starts by constructing an FP-tree from the transaction dataset.
 2. It then recursively mines the FP-tree to find all frequent itemsets.
@@ -28,6 +28,7 @@ Algorithm Overview
 4. It traverses the tree in a bottom-up manner, combining frequent items to generate longer frequent itemsets.
 5. The process continues until all frequent itemsets are discovered.
 
+## Usage Example
 ```julia
 # Load transactions
 txns = load_transactions("transactions.txt", ' ')

--- a/docs/src/algorithms/lcm.md
+++ b/docs/src/algorithms/lcm.md
@@ -21,7 +21,7 @@ A DataFrame object with four columns:
 - `N`: Absolute support count of the itemset
 - `Length`: Number of items in the itemset
 
-Algorithm Overview
+## Algorithm Overview
 
 1. The function starts by identifying frequent items based on the minimum support threshold.
 2. It then recursively explores the search space, using a depth-first approach.
@@ -32,6 +32,7 @@ Algorithm Overview
     - It stops exploring when the support falls below the minimum threshold.
 5. The process continues until all frequent closed itemsets are discovered.
 
+## Usage Example
 ```julia
 # Load transactions
 txns = load_transactions("transactions.txt", ' ')

--- a/docs/src/algorithms/levelwise.md
+++ b/docs/src/algorithms/levelwise.md
@@ -1,6 +1,6 @@
-# Levelwise
+# LevelWise
 
-The `levelwise` function implements a levelwise algorithm for mining closed itemsets proposed by Pasquier et al in 1999. This algorithm, generates all subsets of the closed itemsets, derives their supports, and then returns the results. This particular implementation is designed to take a result datafrom from the various closed itemset mining algorithms in this package as its input.
+The `levelwise` function implements the levelwise algorithm for mining closed itemsets proposed by Pasquier et al in 1999. This algorithm generates all subsets of the closed itemsets, derives their supports, and then returns the results. This particular implementation is designed to take a result datafrom from the various closed itemset mining algorithms in this package as its input.
 
 
 ```@docs
@@ -22,16 +22,20 @@ A DataFrame object with three columns:
 - `N`: Absolute support count of the itemset
 - `Length`: Number of items in the itemset
 
-Algorithm Overview
+## Algorithm Overview
 
 1. The function starts by creating candidates from all subcombinations of the closed itemsets
 2. It computes their supports by finding the smallest closed itemset that is a superset of the candiate
 3. The algorithm loops thorugh, building larger combinations until there are no combinations left
 
+## Usage Example
 ```julia
 # Load transactions
 txns = load_transactions("transactions.txt", ' ')
 
 # Find frequent itemsets with minimum support of 5%
-result = fpclose(txns, 0.05)
+closed_sets = fpclose(txns, 0.05)
+
+# Recover all frequent itemsets from the result
+levelwise(closed_sets,0.05)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,6 +11,6 @@ Key features of RuleMiner.jl include:
 
 ## Contents
 ```@contents
-Pages = ["transactions.md", "algorithms/apriori.md", "algorithms/eclat.md"]
+Pages = ["transactions.md", "algorithms/apriori.md", "algorithms/eclat.md","algorithms/fpgrowth.md","algorithms/charm.md","algorithms/fpclose.md","algorithms/lcm.md","algorithms/carpenter.md","algorithms/levelwise.md"]
 Depth = 2
 ```

--- a/src/fpgrowth.jl
+++ b/src/fpgrowth.jl
@@ -1,5 +1,5 @@
 # fpgrowth.jl
-# FP Growth mining in Julia
+# FP tree-based mining in Julia
 #
 # Copyright (c) 2024 Jared Schwartz
 #
@@ -41,7 +41,7 @@ mutable struct FPTree
     FPTree() = new(FPNode(-1), Dict{Int, Vector{FPNode}}(), ReentrantLock(), Dict{Int, Int}())
 end
 
-# FP Growth
+# Helper Functions
 # -----------------
 function insert_transaction!(tree::FPTree, transaction::Vector{Int}, count::Int=1)
     node = tree.root
@@ -124,40 +124,16 @@ end
 
 # FP Growth
 # -----------------
-function mine_frequent(tree::FPTree, suffix::Vector{Int}, min_support::Int)
-    frequent_patterns = Dict{Vector{Int}, Int}()
-    
-    for (item, nodes) in tree.header_table
-        support = sum(node.support for node in nodes)
-
-        if support >= min_support
-            original_item = tree.col_mapping[item]
-            new_suffix = vcat([original_item], suffix)
-            frequent_patterns[new_suffix] = support
-            
-            # Create and mine conditional FP-tree
-            cond_tree = create_conditional_tree(tree, item, min_support)
-            if !isempty(cond_tree.header_table)
-                merge!(frequent_patterns, mine_frequent(cond_tree, new_suffix, min_support))
-            end
-        end
-    end
-    
-    return frequent_patterns
-end
-
 """
     fpgrowth(txns::Transactions, min_support::Union{Int,Float64})::DataFrame
 
 Identify frequent itemsets in a transactional dataset `txns` with a minimum support: `min_support`.
 
 When an Int value is supplied to min_support, eclat will use absolute support (count) of transactions as minimum support.
-
 When a Float value is supplied, it will use relative support (percentage).
 """
 function fpgrowth(txns::Transactions, min_support::Union{Int,Float64})::DataFrame
-
-    n_transactions = size(txns.matrix,1)
+    n_transactions = size(txns.matrix, 1)
     
     # Handle min_support as a float value
     if min_support isa Float64
@@ -167,21 +143,50 @@ function fpgrowth(txns::Transactions, min_support::Union{Int,Float64})::DataFram
     # Generate tree
     tree = make_FPTree(txns, min_support)
 
+    # Initialize results dictionary
+    Results = Dict{Vector{Int}, Int}()
+
+    function fpgrowth!(frequent_patterns::Dict{Vector{Int}, Int}, tree::FPTree, suffix::Vector{Int}, min_support::Int)
+        for (item, nodes) in tree.header_table
+            # Calculate support for the current item
+            support = sum(node.support for node in nodes)
+    
+            # Skip infrequent items
+            support < min_support && continue
+            
+            # Map the item back to its original index
+            original_item = tree.col_mapping[item]
+            new_suffix = vcat([original_item], suffix)
+            
+            # Add the new itemset to frequent patterns
+            frequent_patterns[new_suffix] = support
+
+            
+            # Create conditional FP-tree
+            cond_tree = create_conditional_tree(tree, item, min_support)
+            
+            # Skip if the conditional tree is empty
+            isempty(cond_tree.header_table) && continue
+            
+            # Recursively mine the conditional FP-tree
+            fpgrowth!(frequent_patterns, cond_tree, new_suffix, min_support)
+        end
+    end
+
     # Mine frequent sets
-    frequent_items = mine_frequent(tree, Int[], min_support)
+    fpgrowth!(Results,tree, Int[], min_support)
     
-    # Convert the dictionary to a DataFrame
-    df = DataFrame(
-        Itemset = [getnames(i,txns) for i in collect(keys(frequent_items))], 
-        Support = collect(values(frequent_items)) ./ n_transactions,
-        N = collect(values(frequent_items)),
-        Length = [length(i) for i in collect(keys(frequent_items))]
-        )
+    # Create the result DataFrame
+    result_df = DataFrame(
+        Itemset = [getnames(itemset, txns) for itemset in keys(Results)],
+        Support = [support / n_transactions for support in values(Results)],
+        N = collect(values(Results)),
+        Length = [length(itemset) for itemset in keys(Results)]
+    )
     
-    # Sort by support in descending order
-    sort!(df, :N, rev=true)
-    
-    return df
+    # Sort results by support in descending order
+    sort!(result_df, :N, rev=true)
+    return result_df
 end
 
 # FPClose
@@ -191,66 +196,15 @@ struct ClosedItemset
     support::Int
 end
 
-function mine_closed(tree::FPTree, suffix::Vector{Int}, min_support::Int)
-    closed_itemsets = Vector{ClosedItemset}()
-    header_items = collect(keys(tree.header_table))
-    
-    # Pre-allocate buffers
-    new_itemset = Vector{Int}(undef, length(suffix) + 1)
-    copyto!(new_itemset, 2, suffix, 1, length(suffix))
-    
-    for item in header_items
-        nodes = tree.header_table[item]
-        support = sum(node.support for node in nodes)
-        
-        if support >= min_support
-            new_itemset[1] = tree.col_mapping[item]
-            
-            # Create conditional FP-tree
-            cond_tree = create_conditional_tree(tree, item, min_support)
-            
-            if isempty(cond_tree.header_table)
-                # If there's no conditional tree, this itemset is closed
-                push!(closed_itemsets, ClosedItemset(copy(new_itemset), support))
-            else
-                sub_closed_itemsets = mine_closed(cond_tree, new_itemset, min_support)
-                
-                # Check if this itemset is closed
-                is_closed = !any(sci -> sci.support == support, sub_closed_itemsets)
-                
-                if is_closed
-                    push!(closed_itemsets, ClosedItemset(copy(new_itemset), support))
-                end
-                
-                # Merge sub_closed_itemsets
-                append!(closed_itemsets, sub_closed_itemsets)
-            end
-        end
-    end
-    
-    # Final pruning step
-    sort!(closed_itemsets, by = ci -> length(ci.itemset))
-    filter!(closed_itemsets) do ci1
-        !any(ci2 -> ci1 !== ci2 && 
-                    length(ci1.itemset) < length(ci2.itemset) && 
-                    ci1.support == ci2.support && 
-                    issubset(ci1.itemset, ci2.itemset),
-            closed_itemsets)
-    end
-    
-    return closed_itemsets
-end
-
 """
     fpclose(txns::Transactions, min_support::Union{Int,Float64})::DataFrame
 
 Identify closed itemsets in a transactional dataset `txns` with a minimum support: `min_support`.
 
 When an Int value is supplied to min_support, eclat will use absolute support (count) of transactions as minimum support.
-
 When a Float value is supplied, it will use relative support (percentage).
 """
-function fpclose(txns::Transactions, min_support::Union{Int,Float64})::DataFrame
+function fpclose(txns::Transactions, min_support::Union{Int,Float64})
     n_transactions = size(txns.matrix, 1)
     
     if min_support isa Float64
@@ -259,13 +213,57 @@ function fpclose(txns::Transactions, min_support::Union{Int,Float64})::DataFrame
 
     tree = make_FPTree(txns, min_support)
     
-    closed_itemsets = mine_closed(tree, Int[], min_support)
+    # Initialize results dictionary
+    Results = Dict{Vector{Int}, Int}()
     
+    function fpclose!(closed_itemsets::Dict{Vector{Int}, Int}, tree::FPTree, suffix::Vector{Int}, min_support::Int)
+        # Process items in reverse order (largest to smallest support)
+        header_items = sort(collect(keys(tree.header_table)), 
+                            by=item -> sum(node.support for node in tree.header_table[item]), 
+                            rev=true)
+        
+        for item in header_items
+            nodes = tree.header_table[item]
+            support = sum(node.support for node in nodes)
+            
+            support < min_support && continue
+            
+            new_itemset = vcat(tree.col_mapping[item], suffix)
+            
+            # Check if this itemset is closed
+            is_closed = !any(closed_itemsets) do (other_itemset, other_support)
+                other_support == support &&
+                issubset(new_itemset, other_itemset)
+            end
+            
+            # If not closed, skip to creating conditional tree
+            if is_closed
+                
+                # Remove any subsets of this itemset with the same support
+                filter!(closed_itemsets) do (itemset, itemset_support)
+                    !(itemset_support == support && issubset(itemset, new_itemset))
+                end
+                
+                # Add the new closed itemset
+                closed_itemsets[new_itemset] = support
+            end
+            
+            # Create conditional FP-tree and continue mining
+            cond_tree = create_conditional_tree(tree, item, min_support)
+            isempty(cond_tree.header_table) && continue
+            
+            fpclose!(closed_itemsets, cond_tree, new_itemset, min_support)
+        end
+    end
+
+    # Start the mining process
+    fpclose!(Results, tree, Int[], min_support)
+
     df = DataFrame(
-        Itemset = [getnames(ci.itemset, txns) for ci in closed_itemsets], 
-        Support = [ci.support / n_transactions for ci in closed_itemsets],
-        N = [ci.support for ci in closed_itemsets],
-        Length = [length(ci.itemset) for ci in closed_itemsets]
+        Itemset = [getnames(itemset, txns) for itemset in keys(Results)], 
+        Support = [support / n_transactions for support in values(Results)],
+        N = collect(values(Results)),
+        Length = [length(itemset) for itemset in keys(Results)]
     )
     
     sort!(df, [:Length, :N], rev=[false, true])


### PR DESCRIPTION
- Reworked CARPENTER to use bitsets instead of matrix columns to save significant memory
- Fixed FPClose to eliminate need for post-processing to achieve correct results
- Refactored all itemset mining functions to have similar structures and naming conventions
- Updated documentation to be structured the same for all algorithms