### PR TITLE
Remove LuxurySparse dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,11 @@ version = "0.3.1"
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-LuxurySparse = "d05aeea4-b7d4-55ac-b691-9e7fabb07ba2"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 DataFrames = "1"
-LuxurySparse = "0.7"
 Combinatorics = "1.0.2"
 julia = "1.6.7"
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Load data to create a Transactions object or alternatively convert an existing 1
 ```julia
 data = load_transactions("retail.txt",' ')
 
-data = transactions(df)
+data = Transactions(df)
 ```
 
 Generate association rules using _A Priori_ with 10% minimum support and a max rule length of 3.

--- a/docs/src/transactions.md
+++ b/docs/src/transactions.md
@@ -1,60 +1,14 @@
 # Transactions Objects
 ## Transactions
-```Julia
-struct Transactions
-    matrix::SparseMatrixCSC{Bool,Int64}
-    colkeys::Dict{Int,String} 
-    linekeys::Dict{Int,String} 
-end
+```@docs
+    Transactions
 ```
-The `Transactions` struct consists of three fields:
-- `matrix`: Sparse matrix showing the locations of the items (columns) in the transactions(rows)
-- `colkeys`: Dictionary mapping column indexes to their original values in the source
-- `linekeys`: Dictionary mapping line indexes to their original values in the source (or generated index number)
-
 ## load_transactions
-    Note: this reads basket-format data, not tabular data!
-
-
 ```@docs
 load_transactions(file::String, delimiter::Char; id_col::Bool = false, skiplines::Int = 0)
 ```
 
-Reads transaction data from a file basket-format file, where each line is a list of items, and returns a Transactions object.
-
-    
-Parameters:
-
-- `file`: Path to the input file
-- `delimiter`: Character used to separate items in each transaction
-- `id_col`: Set to true if the first item in each line is a transaction identifier (default: false)
-- `skiplines`: Number of header lines to skip (optional)
-- `nlines`:Number of lines to read (optional)
-
-Returns: 
-- `Transactions`: A Transactions object with a sparse matrix representing the treansactions (rows) and items (columns) as well as dictionary keys for the names of the rows and columns
-
-
 ## txns\_to\_df
 ```@docs
 txns_to_df(txns::Transactions; indexcol::Bool= false)
-```
-Parameters:
-- `txns`: The `Transactions` object to be converted.
-- `id_col`: If true, an additional 'Index' column is added to the DataFrame containing the values from the linekeys dictionary.
-
-Returns
-- `DataFrame`: A one-hot encoded DataFrame representation of the Transactions object.
-
-
-Usage Examples
-
-```julia
-# Load transactions from a file
-txns = load_transactions("transactions.txt", ' ', id_col=true, skiplines=1)
-
-# Convert a DataFrame to Transactions
-df = DataFrame(Index = [1,2,3], A=[1,0,1], B=[0,1,1], C=[1,1,0])
-
-txns = transactions(df, indexcol=:Index)
 ```

--- a/docs/src/transactions.md
+++ b/docs/src/transactions.md
@@ -34,16 +34,6 @@ Parameters:
 Returns: 
 - `Transactions`: A Transactions object with a sparse matrix representing the treansactions (rows) and items (columns) as well as dictionary keys for the names of the rows and columns
 
-## transactions
-```@docs
-transactions(df::DataFrame;indexcol::Union{Symbol,Nothing}=nothing)
-```
-Converts a one-hot encoded DataFrame into a Transactions object.
-
-Parameters:
-
-- `df`: Input `DataFrame`
-- `indexcol`: Column to use as the index (optional)
 
 ## txns\_to\_df
 ```@docs

--- a/src/RuleMiner.jl
+++ b/src/RuleMiner.jl
@@ -23,7 +23,7 @@
 
 module RuleMiner
 
-using DataFrames, LuxurySparse, Mmap, Base.Threads, SparseArrays, Combinatorics
+using DataFrames, Mmap, Base.Threads, SparseArrays, Combinatorics
 
 include("transactions.jl")
 # Frequent Itemset Mining

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -22,13 +22,89 @@
 # SOFTWARE.
 
 
-export Transactions, getnames, load_transactions, transactions, txns_to_df
+export Transactions, getnames, load_transactions, txns_to_df
 
 
+"""
+    Transactions
+
+A struct representing a collection of transactions in a sparse matrix format.
+
+# Fields
+- `matrix::SparseMatrixCSC{Bool,Int64}`: A sparse boolean matrix representing the transactions.
+  Rows correspond to transactions, columns to items. A `true` value at position (i,j) 
+  indicates that the item j is present in transaction i.
+
+- `colkeys::Dict{Int,String}`: A dictionary mapping column indices to item names.
+  This allows retrieval of the original item names from the matrix column indices.
+
+- `linekeys::Dict{Int,String}`: A dictionary mapping row indices to transaction identifiers.
+  This can be used to map matrix rows back to their original transaction IDs or line numbers.
+
+# Constructors
+    Transactions(matrix::SparseMatrixCSC{Bool,Int64}, colkeys::Dict{Int,String}, linekeys::Dict{Int,String})
+
+    Transactions(df::DataFrame, indexcol::Union{Symbol,Nothing}=nothing)
+
+# Description
+The `Transactions` struct provides an efficient representation of transaction data, 
+particularly useful for large datasets in market basket analysis, association rule mining,
+or similar applications where memory efficiency is crucial.
+
+The sparse matrix representation allows for efficient storage and computation, 
+especially when dealing with datasets where each transaction contains only a small 
+subset of all possible items.
+
+# DataFrame Constructor
+The DataFrame constructor allows direct creation of a `Transactions` object from a DataFrame:
+- `df`: Input DataFrame where each row is a transaction and each column is an item.
+- `indexcol`: Optional. Specifies a column to use as transaction identifiers. 
+   If not provided, row numbers are used as identifiers.
+  
+# Examples
+```julia
+# Create from existing data
+matrix = SparseMatrixCSC{Bool,Int64}(...)
+colkeys = Dict(1 => "apple", 2 => "banana", 3 => "orange")
+linekeys = Dict(1 => "T001", 2 => "T002", 3 => "T003")
+txns = Transactions(matrix, colkeys, linekeys)
+
+# Create from DataFrame
+df = DataFrame(
+    ID = ["T1", "T2", "T3"],
+    Apple = [1, 0, 1],
+    Banana = [1, 1, 0],
+    Orange = [0, 1, 1]
+)
+txns_from_df = Transactions(df, indexcol=:ID)
+
+# Access data
+item_in_transaction = txns.matrix[2, 1]  # Check if item 1 is in transaction 2
+item_name = txns.colkeys[1]              # Get the name of item 1
+transaction_id = txns.linekeys[2]
+```
+"""
 struct Transactions
     matrix::SparseMatrixCSC{Bool,Int64} # Sparse matrix showing the locations of the items (columns) in the transactions(rows)
     colkeys::Dict{Int,String} # Dictionary mapping column indexes to their original values in the source
     linekeys::Dict{Int,String} # Dictionary mapping line indexes to their original values in the source (or generated index #)
+    
+    # Original constructor
+    Transactions(matrix::SparseMatrixCSC{Bool,Int64}, colkeys::Dict{Int,String}, linekeys::Dict{Int,String}) = new(matrix, colkeys, linekeys)
+
+    # Constructor from DataFrame
+    function Transactions(df::DataFrame, indexcol::Union{Symbol,Nothing}=nothing)
+        df = copy(df)
+        if !isnothing(indexcol)
+            linekeys = Dict(zip(1:length(df[:,indexcol]), string.(df[:,indexcol])))
+            select!(df, Not(indexcol))
+        else
+            linekeys = Dict(zip(1:length(df[:,1]), string.(1:length(df[:,1]))))
+        end
+        colkeys = Dict(zip(1:length(names(df)), names(df)))
+        matrix = Bool.(Matrix(df)) |> SparseMatrixCSC
+        new(matrix, colkeys, linekeys)
+    end
 end
 
 # Helper function to take indexes and return their column names
@@ -37,117 +113,202 @@ function getnames(indexes::Vector{Int},txns::Transactions)
 end
 
 """
-    load_transactions(file::String, delimiter::Char; id_col::Bool= false, skiplines::Int= 0, nlines::Int= 0)::Transactions
+    load_transactions(file::String, delimiter::Char; id_col::Bool = false, skiplines::Int = 0, nlines::Int = 0)::Transactions
 
-Read transaction data from a `file` where each line is a list of items separated by a given `delimiter`
+Load transaction data from a file and return a Transactions struct.
 
-If the first item of each list is a transaction identifier, set `id_col` to `true`
+# Arguments
+- `file::String`: Path to the input file containing transaction data.
+- `delimiter::Char`: Character used to separate items in each transaction.
 
-Specify the number header lines to skip with `skiplines`
+# Keyword Arguments
+- `id_col::Bool = false`: If true, treats the first item in each line as a transaction identifier.
+- `skiplines::Int = 0`: Number of lines to skip at the beginning of the file (e.g., for headers).
+- `nlines::Int = 0`: Maximum number of lines to read. If 0, reads the entire file.
 
-Specify a specific number of lines to read with `nlines`
+# Returns
+- `Transactions`: A struct containing:
+  - `matrix`: A sparse boolean matrix where rows represent transactions and columns represent items.
+  - `colkeys`: A dictionary mapping column indices to item names.
+  - `linekeys`: A dictionary mapping row indices to transaction identifiers.
+
+# Description
+This function reads transaction data from a file, where each line represents a transaction
+and items are separated by the specified delimiter. It constructs a sparse matrix 
+representation of the transactions, with rows as transactions and columns as unique items.
+
+The function uses memory mapping to read the file and construct
+the sparse matrix directly without materializing dense intermediate representations.
+
+# Note
+This function may not be suitable for extremely large files that exceed available system memory.
+
+# Example
+```julia
+txns = load_transactions("transactions.txt", ',', id_col=true, skiplines=1)
+```
 """
 function load_transactions(file::String, delimiter::Char; id_col::Bool = false, skiplines::Int = 0, nlines::Int = 0)::Transactions
-
+    # Memory-map the file for efficient reading
     io = Mmap.mmap(file)
     
-    # Estimate the number of lines and items
-    estimated_lines = count(==(UInt8('\n')), io) - abs(skiplines)
-    estimated_items =  count(==(UInt8(delimiter)), io) + estimated_lines + 1
+    # Estimate the number of lines and items for preallocation
+    estimated_lines = count(==(UInt8('\n')), io) - skiplines
+    estimated_items = count(==(UInt8(delimiter)), io) + estimated_lines
 
     # Initialize data structures
-    ItemKey = Dict{String, Int}()
-    RowKeys = Dict{Int, String}()
-    RowValues = Vector{Int}(undef, estimated_items)
-    ColumnValues = Vector{Int}(undef, estimated_items)
+    ItemKey = Dict{String, Int}()  # Maps items to their unique IDs
+    RowKeys = Dict{Int, String}()  # Maps row numbers to their identifiers
+    ColumnValues = Int[]  # Stores column indices for sparse matrix
+    RowValues = Int[]     # Stores row indices for sparse matrix
     
-    sizehint!(ItemKey, estimated_items)
+    # Provide size hints to reduce reallocation
+    sizehint!(ItemKey, div(estimated_items, 2))
     sizehint!(RowKeys, estimated_lines)
+    sizehint!(ColumnValues, estimated_items)
+    sizehint!(RowValues, estimated_items)
     
+    # Initialize Loop Variables
     line_number = 1
     item_id = 1
-    value_index = 1
-    skipcounter = abs(skiplines)
+    nlines = abs(nlines)
     
-    # Read File
+    
     for line in eachline(IOBuffer(io))
-        if skipcounter > 0
-            skipcounter -=1
-            continue
-        end
-        items = split(line, delimiter;keepempty=false)
-        first_item = true
-        if !id_col
-            RowKeys[line_number] = string(line_number)
-        end
-        for item in items
-            if (id_col * first_item)
+        # Skip lines if necessary
+        skiplines > 0 && (skiplines -= 1; continue)
+
+        # Break if we've reached the specified number of lines
+        nlines != 0 && line_number > nlines && break
+
+        # Split the line into items
+        items = split(line, delimiter; keepempty=false)
+        
+        # If there's no ID column, use the line number as the row key
+        !id_col && (RowKeys[line_number] = string(line_number))
+        
+        # Process each item in the line
+        for (index, item) in enumerate(items)
+            # If there's an ID column, use the first item as the row key
+            if id_col && index == 1
                 RowKeys[line_number] = item
-            else
-                if !haskey(ItemKey, item)
-                    ItemKey[item] = item_id
-                    item_id += 1
-                end
-                @inbounds ColumnValues[value_index] = ItemKey[item]
-                @inbounds RowValues[value_index] = line_number
-                value_index += 1
+                continue
             end
-            first_item = false
+            
+            # Assign a unique ID to each item if it doesn't have one
+            if !haskey(ItemKey, item)
+                ItemKey[item] = item_id
+                item_id += 1
+            end
+            
+            # Record the item's presence in this transaction
+            push!(ColumnValues, ItemKey[item])
+            push!(RowValues, line_number)
         end
-        if nlines != 0 && line_number == abs(nlines)
-            break
-        end
+        
         line_number += 1
     end
 
-    # Trim excess capacity
-    resize!(RowValues, value_index - 1)
-    resize!(ColumnValues, value_index - 1)
+    # Create the sparse matrix
+    n = length(ItemKey)  # Number of unique items
+    m = line_number - 1  # Number of transactions
+    colptr, rowval = convert_csc!(ColumnValues, RowValues, n)
+    nzval = fill(true, length(ColumnValues))
 
-    # Reverse item Dict
-    ColKeys = Dict(value => key for (key, value) in ItemKey)
-
-    # Get Matrix Dimensions
-    m = length(RowKeys)
-    n = length(ColKeys)
-
-    # Construct Matrix
-    matrix = SparseMatrixCOO(RowValues, ColumnValues, [true for i in ColumnValues], m, n) |> SparseMatrixCSC
+    matrix = SparseMatrixCSC(m, n, colptr, rowval, nzval)
     
-    return Transactions(matrix,ColKeys,RowKeys)
+    # Create a reverse mapping of item IDs to items
+    ColKeys = Dict(v => k for (k, v) in ItemKey)
+    
+    # Return the Txns struct
+    return Transactions(matrix, ColKeys, RowKeys)
 end
 
 """
-    transactions(df::DataFrame; indexcol::Union{Symbol,Nothing}= nothing)::Transactions
+    convert_csc!(column_values::Vector{Int}, row_values::Vector{Int}, n_cols::Int) -> Tuple{Vector{Int}, Vector{Int}}
 
-Converts a one-hot encoded `DataFrame` object into a `Transactions` object
+Convert COO (Coordinate) format sparse matrix data to CSC (Compressed Sparse Column) format.
 
-Designate a column as an index column with `indexcol` 
+# Arguments
+- `column_values::Vector{Int}`: Vector of column indices in COO format.
+- `row_values::Vector{Int}`: Vector of row indices in COO format.
+- `n_cols::Int`: Number of columns in the matrix.
+
+# Returns
+- `Tuple{Vector{Int}, Vector{Int}}`: A tuple containing:
+  - `colptr`: Column pointer array for CSC format.
+  - `rowval`: Row indices array for CSC format.
+
+# Description
+This function takes sparse matrix data in COO format (column_values and row_values)
+and converts it to CSC format. It sorts the input data by column indices and
+computes the column pointer array required for CSC representation.
+
+# Note
+This function assumes that the input vectors are of equal length and contain valid indices.
+The caller is responsible for ensuring this precondition.
+
+# Example
+```julia
+colptr, rowval = convert_csc!([1,2,1,3], [1,2,3,1], 3)
+```
 """
-function transactions(df::DataFrame; indexcol::Union{Symbol,Nothing}= nothing)::Transactions
-    df = copy(df)
-    if !isnothing(indexcol)
-        lineindex = Dict(zip(1:length(df[:,indexcol]),string.(df[:,indexcol])))
-        select!(df,Not(indexcol))
-    else
-        lineindex = Dict(zip(1:length(df[:,1]),string.(1:length(df[:,1]))))
+function convert_csc!(column_values, row_values, n_cols)
+    
+    # Sort both arrays based on column values
+    p = sortperm(column_values)
+    permute!(column_values, p)
+    permute!(row_values, p)
+    
+    # Initialize colptr
+    colptr = zeros(Int, n_cols + 1)
+    colptr[1] = 1
+    
+    # Fill colptr
+    for col in column_values
+        colptr[col + 1] += 1
     end
-    colindex = Dict(zip(1:length(names(df)),names(df)))
-
-    matrix = Bool.(Matrix(df)) |> SparseMatrixCSC
-
-    return Transactions(matrix,colindex,lineindex)
+    
+    # Convert counts to cumulative sum
+    cumsum!(colptr,colptr)
+    
+    return colptr, row_values
 end
 
 
 """
-    txns_to_df(txns::Transactions; id_col::Bool= false)::DataFrame
+    txns_to_df(txns::Transactions, id_col::Bool = false)::DataFrame
 
-Convert a `Transactions` object to a `DataFrame`.
-Specify whether the `Transactions` `linekey` field should be included as an Index column with `indexcol`
+Convert a Transactions object into a DataFrame.
 
+# Arguments
+- `txns::Transactions`: The Transactions object to be converted.
+
+# Keyword Arguments
+- `id_col::Bool = false`: If true, includes an 'Index' column with transaction identifiers.
+
+# Returns
+- `DataFrame`: A DataFrame representation of the transactions.
+
+# Description
+This function converts a Transactions object, which uses a sparse matrix representation,
+into a DataFrame. Each row of the resulting DataFrame represents a transaction,
+and each column represents an item.
+
+The values in the DataFrame are integers, where 1 indicates the presence of an item
+in a transaction, and 0 indicates its absence.
+
+# Features
+- Preserves the original item names as column names.
+- Optionally includes an 'Index' column with the original transaction identifiers.
+
+# Example
+```julia
+# Assuming 'txns' is a pre-existing Transactions object
+df = txns_to_df(txns, id_col=true)
+```
 """
-function txns_to_df(txns::Transactions; id_col::Bool= false)::DataFrame
+function txns_to_df(txns::Transactions, id_col::Bool= false)::DataFrame
     df = DataFrame(Int.(Matrix(txns.matrix)),:auto)
     rename!(df,txns.colkeys)
     if id_col

--- a/src/transactions.jl
+++ b/src/transactions.jl
@@ -283,9 +283,7 @@ Convert a Transactions object into a DataFrame.
 
 # Arguments
 - `txns::Transactions`: The Transactions object to be converted.
-
-# Keyword Arguments
-- `id_col::Bool = false`: If true, includes an 'Index' column with transaction identifiers.
+- `id_col::Bool = false`: (Optional) If true, includes an 'Index' column with transaction identifiers.
 
 # Returns
 - `DataFrame`: A DataFrame representation of the transactions.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,29 +3,34 @@ using Test
 
 
 @testset "transactions.jl" begin
+
+    item_vals = ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
+    nonindex_vals = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+    index_vals = ["1111", "1112", "1113", "1114", "1115", "1116", "1117", "1118", "1119"]
+
     @testset "Load Files" begin
         @testset "regular load" begin
             data = load_transactions(joinpath(@__DIR__,"files/data.txt"),',')
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+            @test sort(collect(values(data.colkeys))) == item_vals
+            @test sort(collect(values(data.linekeys))) == nonindex_vals
         end
 
         @testset "line indexes" begin
             data = load_transactions(joinpath(@__DIR__,"files/data_indexed.txt"),',';id_col = true)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1111", "1112", "1113", "1114", "1115", "1116", "1117", "1118", "1119"]
+            @test sort(collect(values(data.colkeys))) == item_vals
+            @test sort(collect(values(data.linekeys))) == index_vals
         end
 
         @testset "skip lines" begin
             data = load_transactions(joinpath(@__DIR__,"files/data_header.txt"),',';skiplines=2)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+            @test sort(collect(values(data.colkeys))) == item_vals
+            @test sort(collect(values(data.linekeys))) == nonindex_vals
         end
 
         @testset "n lines" begin
@@ -41,22 +46,22 @@ using Test
         data = load_transactions(joinpath(@__DIR__,"files/data.txt"),',')
         dftest = txns_to_df(data)
         data = load_transactions(joinpath(@__DIR__,"files/data_indexed.txt"),',';id_col = true)
-        dftest_index =  txns_to_df(data,id_col=true)
+        dftest_index =  txns_to_df(data,true)
 
         @testset "without index" begin
-            data = transactions(dftest)
+            data = Transactions(dftest)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+            @test sort(collect(values(data.colkeys))) == item_vals
+            @test sort(collect(values(data.linekeys))) == nonindex_vals
         end
 
         @testset "with index" begin
-            data = transactions(dftest_index;indexcol=:Index)
+            data = Transactions(dftest_index,:Index)
             @test size(data.matrix) == (9,16)
             @test sum(data.matrix) == 36
-            @test sort(collect(values(data.colkeys))) == ["bacon", "beer", "bread", "buns", "butter", "cheese", "eggs", "flour", "ham", "hamburger", "hot dogs", "ketchup", "milk", "mustard", "sugar", "turkey"]
-            @test sort(collect(values(data.linekeys))) == ["1111", "1112", "1113", "1114", "1115", "1116", "1117", "1118", "1119"]
+            @test sort(collect(values(data.colkeys))) == item_vals
+            @test sort(collect(values(data.linekeys))) == index_vals
         end
 
     end


### PR DESCRIPTION
LuxurySparse seems to have been abandoned, with the last release being more than a year old.

While LuxurySparse made it possible to quickly implement COO to CSC conversion, that is all it is used for in RuleMiner.

The goal of this PR is to remove the dependency and write a helper function in transactions.jl that accomplishes the same task and remove the dependency on LuxurySparse.