### PR TITLE
Optimize Txns file reading

### DIFF
--- a/src/data_structures/seqtxns.jl
+++ b/src/data_structures/seqtxns.jl
@@ -151,7 +151,7 @@ struct SeqTxns <: Transactions
     
         io = Mmap.mmap(file)
         
-        est_lines, est_sets, est_items = RuleMiner.delimcounter(io, '\n', set_delimiter, item_delimiter)
+        est_lines, est_sets, est_items = RuleMiner.delimcounter(io, UInt8[set_delimiter], UInt8[item_delimiter])
         est_lines = est_lines + 1 - skiplines   # Est. lines is one more than num of line delims minus any skipped
         est_sets = est_sets + est_lines         # Line delims also act as set delims
         est_items = est_items + est_sets        # Set delims also act as item delims


### PR DESCRIPTION
Updated Txns file constructor to significantly reduce allocations and improve processing speed.

- iterate through Mmap array directly instead of splitting into strings with `eachline()` and then items with `eachsplit()`
- use views of the Mmap array for the item de-duplication to eliminate allocations in the dictionary creation

Allocations now scale linearly with the number of unique `colkeys` and, if specified, `rowkeys`. These allocations are unavoidable with the way that `unsafe_string()` dereferencing works.

In testing, reading files now is now ~2x faster and uses ~50% less memory. 