### PR TITLE
Move to DocumenterViteress.jl for docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-RuleMiner = "26420b10-3f9f-4b54-bd85-e6b3d5a44d3c"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
+RuleMiner = "26420b10-3f9f-4b54-bd85-e6b3d5a44d3c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,8 @@
-using Documenter, RuleMiner,DataFrames
+using Documenter, RuleMiner,DataFrames,DocumenterVitepress
 
 
 makedocs(
-    format = Documenter.HTML(prettyurls = haskey(ENV, "CI")),
+    format = DocumenterVitepress.MarkdownVitepress(repo = "github.com/JaredSchwartz/RuleMiner.jl"),
     sitename="RuleMiner.jl",
     pagesonly = true,
     draft = false,
@@ -20,6 +20,7 @@ makedocs(
     warnonly = [:missing_docs, :cross_references],
 )
 
-deploydocs(
-    repo = "github.com/JaredSchwartz/RuleMiner.jl.git",
+deploydocs(;
+    repo = "github.com/JaredSchwartz/RuleMiner.jl",
+    target = "build",
 )

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "docs:dev": "vitepress dev build/.documenter",
+    "docs:build": "vitepress build build/.documenter",
+    "docs:preview": "vitepress preview build/.documenter"
+  },
+  "dependencies": {
+    "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.12.1",
+    "@shikijs/transformers": "^2.0.3",
+    "markdown-it": "^14.1.0",
+    "markdown-it-footnote": "^4.0.0",
+    "markdown-it-mathjax3": "^4.3.2",
+    "vitepress": "^1.6.3",
+    "vitepress-plugin-tabs": "^0.5.0"
+  }
+}


### PR DESCRIPTION
This branch moves to DocumenterVitepress.jl for docs instead of Documenter.jl.