### PR TITLE
Add pretty printing format (MIME"text/plain") to println() output

### DIFF
--- a/src/data_structures/fptree.jl
+++ b/src/data_structures/fptree.jl
@@ -163,6 +163,8 @@ mutable struct FPTree
     end
 end
 
+Base.show(io::IO, tree::FPTree) = show(io, MIME("text/plain"), tree)
+
 function Base.show(io::IO, ::MIME"text/plain", tree::FPTree)
     num_items = length(tree.header_table)
     num_nodes = sum([length(i) for i in values(tree.header_table)])

--- a/src/data_structures/txns.jl
+++ b/src/data_structures/txns.jl
@@ -252,6 +252,8 @@ function Base.getindex(txns::Txns, i::Integer)
     return txns.colkeys[items]
 end
 
+Base.show(io::IO, txns::Txns) = show(io, MIME("text/plain"), txns)
+
 function Base.show(io::IO, ::MIME"text/plain", txns::Txns)
     n_transactions, n_items = size(txns.matrix)
     n_nonzero = nnz(txns.matrix)

--- a/test/data_structures.jl
+++ b/test/data_structures.jl
@@ -2,7 +2,7 @@
 function trunc_tester(object, nlines::Int, ncols::Int)
     buf = IOBuffer()
     io = IOContext(buf, :limit=>true, :displaysize=>(nlines, ncols))
-    show(io, MIME"text/plain"(), object)
+    show(io, object)
     result = String(take!(buf))
     return(result)
 end


### PR DESCRIPTION
Because this package is heavily inspired by DataFrames.jl and is also designed primarily for exploratory use, it makes sense MIME"text/plain" method for both Transactions objects and FPTree objects. The internal structures of these data types are not exactly readable in the REPL otherwise anyway, and thus println() was largely useless.

This PR adds a Base.show() method so `println(Txns)` and `println(FPTree)` display pretty-printed output.