### PR TITLE
Fix improper thread local storage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,16 @@ version = "0.6.3"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-DataFrames = "1"
 Combinatorics = "1.0.2"
-julia = "1.10"
+DataFrames = "1"
+OhMyThreads = "0.7.0"
 PrettyTables = "2.3 - 2.4"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/RuleMiner.jl
+++ b/src/RuleMiner.jl
@@ -9,6 +9,7 @@ module RuleMiner
 using DataFrames
 using Combinatorics
 using PrettyTables
+using OhMyThreads
 
 # Base and Standard Library Dependencies
 using Mmap

--- a/src/association_rules/apriori.jl
+++ b/src/association_rules/apriori.jl
@@ -53,20 +53,17 @@ function create_level_one_rules(items, basenum, n_transactions, min_confidence)
 end
 
 # helper function to generate all candidates at a given k value
-function generate_candidates(current_level::Set{Vector{Int}}, k::Int, thread_buffers, candidate_chunks)
+function generate_candidates(current_level::Set{Vector{Int}}, k::Int, buffer_channel::Channel{ThreadBuffers}, candidate_channel::Channel{Set{Vector{Int}}})
     level_arr = collect(current_level)
     
     isempty(level_arr) && return Set{Vector{Int}}()
     
-    # Clear previous candidate chunks
-    foreach(empty!, candidate_chunks)
-    
     @sync begin
         for i in 1:length(level_arr)
-            @spawn begin
-                tid = threadid()
-                local_candidates = candidate_chunks[tid]
-                buffer = thread_buffers[tid].lineage
+            Threads.@spawn begin
+                # Take resources from channels
+                buf = take!(buffer_channel)
+                local_candidates = take!(candidate_channel)
                 
                 for j in (i+1):length(level_arr)
                     # Early skip for non-matching prefixes
@@ -74,21 +71,31 @@ function generate_candidates(current_level::Set{Vector{Int}}, k::Int, thread_buf
                         continue
                     end
                     
-                    empty!(buffer)
-                    append!(buffer, level_arr[i])
-                    append!(buffer, level_arr[j])
-                    unique!(sort!(buffer))
+                    empty!(buf.lineage)
+                    append!(buf.lineage, level_arr[i])
+                    append!(buf.lineage, level_arr[j])
+                    unique!(sort!(buf.lineage))
                     
-                    length(buffer) == k && push!(local_candidates, copy(buffer))
+                    length(buf.lineage) == k && push!(local_candidates, copy(buf.lineage))
                 end
+                
+                # Return resources to channels
+                put!(candidate_channel, local_candidates)
+                put!(buffer_channel, buf)
             end
         end
     end
     
     # Combine all candidates
     candidates = Set{Vector{Int}}()
-    for chunk in candidate_chunks
-        union!(candidates, chunk)
+    
+    # We don't want to close the channel as it will be reused
+    # Instead, collect its current contents
+    for _ in 1:nthreads()
+        local_candidates = take!(candidate_channel)
+        union!(candidates, local_candidates)
+        # Return the empty set back to the channel for reuse
+        put!(candidate_channel, Set{Vector{Int}}())
     end
     
     return candidates
@@ -96,6 +103,9 @@ end
 
 # helper function to generate arules based on candidates at k
 function process_candidate(lineage, subtxns, min_support, min_confidence, buf)
+    # Clear previous results
+    empty!(buf.rules)
+    
     # Check support
     fill!(buf.mask, true)
     for item in lineage
@@ -194,10 +204,19 @@ function apriori(txns::Transactions, min_support::Union{Int,Float64}, min_confid
     
     subtxns, items = RuleMiner.prune_matrix(txns.matrix, min_support)
     n_rows = size(subtxns, 1)
+    num_buffers = Threads.nthreads()
     
-    # Initialize thread resources
-    thread_buffers = [ThreadBuffers(n_rows) for _ in 1:nthreads()]
-    candidate_chunks = [Set{Vector{Int}}() for _ in 1:nthreads()]
+    # Create channel of thread buffers
+    buffer_channel = Channel{ThreadBuffers}(num_buffers)
+    for _ in 1:num_buffers
+        put!(buffer_channel, ThreadBuffers(n_rows))
+    end
+    
+    # Create channel for candidate chunks
+    candidate_channel = Channel{Set{Vector{Int}}}(num_buffers)
+    for _ in 1:num_buffers
+        put!(candidate_channel, Set{Vector{Int}}())
+    end
     
     # Process level one
     level_rules, current_level = create_level_one_rules(items, basenum, n_transactions, min_confidence)
@@ -206,25 +225,35 @@ function apriori(txns::Transactions, min_support::Union{Int,Float64}, min_confid
     # Main loop for level-wise processing
     k = 2
     while !isempty(current_level) && (max_length == 0 || k <= max_length)
-        candidates = generate_candidates(current_level, k, thread_buffers, candidate_chunks)
+        candidates = generate_candidates(current_level, k, buffer_channel, candidate_channel)
         isempty(candidates) && break
         
-        # Clear thread-local rule storage
-        foreach(buf -> empty!(buf.rules), thread_buffers)
+        # Channel for collecting rules from parallel tasks
+        rules_channel = Channel{Vector{Arule}}(Inf)
         
         @sync begin
             for lineage in candidates
-                @spawn begin
-                    tid = threadid()
-                    process_candidate(lineage, subtxns, min_support, min_confidence, thread_buffers[tid])
+                Threads.@spawn begin
+                    # Take a buffer from the channel
+                    buf = take!(buffer_channel)
+                    process_candidate(lineage, subtxns, min_support, min_confidence, buf)
+
+                    # Send collected rules to the rules channel
+                    if !isempty(buf.rules)
+                        put!(rules_channel, copy(buf.rules))
+                        empty!(buf.rules) # Clear for reuse
+                    end
+                    
+                    put!(buffer_channel, buf)
                 end
             end
         end
         
-        # Combine thread-local rules
+        # Collect all rules from the channel
+        close(rules_channel)
         level_rules = Vector{Arule}()
-        for buf in thread_buffers
-            append!(level_rules, buf.rules)
+        for rules_batch in rules_channel
+            append!(level_rules, rules_batch)
         end
         append!(rules, level_rules)
         
@@ -233,6 +262,7 @@ function apriori(txns::Transactions, min_support::Union{Int,Float64}, min_confid
         k += 1
     end
     
+    # Create the output DataFrame 
     df = DataFrame(
         LHS = [RuleMiner.getnames([items[i] for i in rule.lhs], txns) for rule in rules],
         RHS = [txns.colkeys[items[rule.rhs]] for rule in rules],


### PR DESCRIPTION
Resolves #56 by using OhMyThreads  `channel` constructions to handle thread-local storage while spawning multiple tasks.

This eliminates the reliance on threadid and thread indexing in multithreading implementations in this package. Everything now either uses `Threads.ReentrantLock` strategies with global storage or channels.