### PR TITLE
Update parallelism

### DIFF
--- a/docs/src/tutorials/getting_started.md
+++ b/docs/src/tutorials/getting_started.md
@@ -26,20 +26,22 @@ The mining algorithms in RuleMiner utilize multithreading to process data concur
 
 To enable multithreading when launching Julia from a terminal, use the `-t` argument:
 ```shell
-julia -t auto # Use all available CPU cores
+julia -t auto # Use all available CPU cores for computation
 ```
 ```shell
-julia -t 8 # Dedicate 8 cores specifically
+julia -t 8 # Dedicate 8 cores for computation
 ```
+
+Starting with Julia 1.12, the above commands automatically include one additional interactive thread (so `julia -t 8` creates 8 computational threads + 1 interactive thread for 9 total), which helps keep Julia responsive during computation.
 
 It is recommended to use the `auto` setting with RuleMiner.jl for best performance.
 
 If you're using the official Julia extension for VS Code, the parameter passed into -t is called `julia.NumThreads` in VS Code settings for all Julia instances created in that IDE. Other IDEs may have similar ways to configure the arguments passed into Julia on startup.
 
-You can verify the number of threads available to Julia with:
+You can verify the number of computational threads available to Julia with:
 ```julia
 using Base.Threads
-println("Julia is using $(nthreads()) threads")
+println("Julia is using $(nthreads(:default)) computational threads")
 ```
 ## Creating a `Txns` object
 

--- a/src/association_rules/apriori.jl
+++ b/src/association_rules/apriori.jl
@@ -88,7 +88,7 @@ function apriori(txns::Transactions, min_support::Union{Int,Float64}, min_confid
     n_rows = size(subtxns, 1)
     
     # Set up processing channels
-    num_buffers = Threads.nthreads()
+    num_buffers = nthreads(:default)
 
     buffer_channel = Channel{ThreadBuffer}(num_buffers)
     for _ in 1:num_buffers
@@ -113,7 +113,7 @@ function apriori(txns::Transactions, min_support::Union{Int,Float64}, min_confid
         
         @sync begin
             for lineage in candidates
-                Threads.@spawn begin
+                @spawn begin
                     buf = take!(buffer_channel)
                     process_candidate(lineage, subtxns, min_support, min_confidence, buf)
 
@@ -185,7 +185,7 @@ function generate_candidates(current_level::Set{Vector{Int}}, k::Int, buffer_cha
     
     @sync begin
         for i in 1:length(level_arr)
-            Threads.@spawn begin
+            @spawn begin
                 buf = take!(buffer_channel)
                 local_candidates = take!(candidate_channel)
                 


### PR DESCRIPTION
- Use `atomic_add!()` and atomic ints for work distribution instead of channels to reduce overhead (and enumerate tuple creation)
- Update to use `nthreads(:default)` syntax explicitly to ensure counting only threads in the default worker threadpool for parallelism