### PR TITLE
Deprecate `txns_to_df`

### DIFF
--- a/docs/src/api_reference.md
+++ b/docs/src/api_reference.md
@@ -56,6 +56,11 @@ recover_maximal(df::DataFrame)
     Txns
 ```
 
+### Conversion of Transactions to DataFrame
+```@docs
+    DataFrames.DataFrame(txns::Txns)
+```
+
 ### FP Mining Objects
 
 ```@docs
@@ -63,9 +68,4 @@ recover_maximal(df::DataFrame)
 ```
 ```@docs
     FPNode
-```
-
-## Utility Functions
-```@docs
-txns_to_df(txns::Txns)
 ```


### PR DESCRIPTION
Replace `txns_to_df` with a proper `DataFrames.DataFrame()` constructor.

This patch doesn't immediately remove the old functions, but reassigns them to call the new DataFrame constructors and throws a deprecation warning. `txns_to_df` function will be removed in a future release.