### PR TITLE
Upgrade to PrettyTables.jl 3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Combinatorics = "1.0.2"
-DataFrames = "1"
-PrettyTables = "2.3 - 2.4"
+DataFrames = "1.8"
+PrettyTables = "3"
 julia = "1.10"
 
 [extras]

--- a/src/data_structures/seqtxns.jl
+++ b/src/data_structures/seqtxns.jl
@@ -383,22 +383,20 @@ function Base.show(io::IO, ::MIME"text/plain", seqtxns::SeqTxns)
         )
     end
 
-    # Display table
-    tf = TextFormat(
-        up_intersection='─',
-        bottom_intersection='─',
-        column='│',
-        row='─',
-        hlines=[:header]
+    format = TextTableFormat(;
+        @text__no_horizontal_lines,
+        vertical_line_at_beginning = false,
+        vertical_line_after_data_columns = false,
+        horizontal_line_after_column_labels = true,
     )
-
-    pretty_table(io, display_data;
-        header=["Sequence", "Transaction", "Items"],
-        tf=tf,
-        crop=:none,
-        show_row_number=false,
-        columns_width=[seq_width, idx_width, items_width],
-        alignment=[:r, :l, :l],
-        vlines=[1, 2]
+    
+    pretty_table(
+        io, 
+        display_data;
+        column_labels = ["Sequence", "Transaction", "Items"],
+        alignment = [:r, :l, :l],
+        table_format = format,
+        maximum_number_of_columns = -1,
+        fit_table_in_display_horizontally = false
     )
 end

--- a/src/data_structures/txns.jl
+++ b/src/data_structures/txns.jl
@@ -311,22 +311,20 @@ function Base.show(io::IO, ::MIME"text/plain", txns::Txns)
         )
     end 
 
-    # Display table
-    tf = TextFormat(
-        up_intersection='─',
-        bottom_intersection='─',
-        column='│',
-        row='─',
-        hlines=[:header]
+    format = TextTableFormat(;
+        @text__no_horizontal_lines,
+        vertical_line_at_beginning = false,
+        vertical_line_after_data_columns = false,
+        horizontal_line_after_column_labels = true,
     )
 
-    pretty_table(io, display_data;
-        header=["Index", "Items"],
-        tf=tf,
-        crop=:none,
-        show_row_number=false,
-        columns_width=[index_width, items_width],
-        alignment=[:r, :l],
-        vlines=[1]
+    # Display table using PrettyTables.jl 3.0 API
+    pretty_table(
+        io, 
+        display_data;
+        column_labels = ["Index","Items"],
+        alignment = [:r,:l],
+        table_format = format,
+        fit_table_in_display_horizontally = false
     )
 end


### PR DESCRIPTION
Updated `base.show()` methods to support new PrettyTables API and bumped both PrettyTables.jl and DataFrames.jl version compat